### PR TITLE
CU-86c39q6uc - Create tenant controller

### DIFF
--- a/apps/klubiq-dashboard/src/klubiq-dashboard.module.ts
+++ b/apps/klubiq-dashboard/src/klubiq-dashboard.module.ts
@@ -38,6 +38,7 @@ import { CsrfMiddleware } from './security/csrf.middleware';
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { Cache } from 'cache-manager';
 import { filteredRoutes } from './security/security-helpers';
+import { TenantsModule } from './tenants/tenants.module';
 
 @Module({
 	imports: [
@@ -68,6 +69,7 @@ import { filteredRoutes } from './security/security-helpers';
 		NotificationsModule,
 		EventListenerModule,
 		SchedulersModule,
+		TenantsModule,
 	],
 	providers: [
 		ApikeyGuard,

--- a/apps/klubiq-dashboard/src/tenants/controller/tenants.controller.ts
+++ b/apps/klubiq-dashboard/src/tenants/controller/tenants.controller.ts
@@ -7,7 +7,7 @@ import { GetTenantDto } from '../dto/requests/get-tenant-dto';
 @ApiTags('tenant')
 @Controller('tenants')
 @ApiBearerAuth()
-@Auth(AuthType.None)
+@Auth(AuthType.Bearer)
 export class TenantsController {
 	constructor(private readonly tenantsService: TenantsService) {}
 

--- a/apps/klubiq-dashboard/src/tenants/controller/tenants.controller.ts
+++ b/apps/klubiq-dashboard/src/tenants/controller/tenants.controller.ts
@@ -1,0 +1,33 @@
+import { Controller, Get, Param, Query } from '@nestjs/common';
+import { TenantsService } from '../services/tenants.service';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+import { Auth, AuthType } from '@app/auth';
+import { GetTenantDto } from '../dto/requests/get-tenant-dto';
+
+@ApiTags('tenant')
+@Controller('tenants')
+@ApiBearerAuth()
+@Auth(AuthType.None)
+export class TenantsController {
+	constructor(private readonly tenantsService: TenantsService) {}
+
+	@Get('lease')
+	getAllTenantwithLease(@Query() getTenantDto: GetTenantDto) {
+		return this.tenantsService.findAll(getTenantDto);
+	}
+
+	@Get('lease/:id')
+	getTenantPerLease(@Param('id') id: string) {
+		return this.tenantsService.findByLeaseId(id);
+	}
+
+	@Get(':id')
+	getTenantDetails(@Param('id') id: string) {
+		return this.tenantsService.findOne(id);
+	}
+
+	@Get('organization/:organizationUuid')
+	getOrganizationTenants(@Param('organizationUuid') organizationUuid: string) {
+		return this.tenantsService.findByOrganizationId(organizationUuid);
+	}
+}

--- a/apps/klubiq-dashboard/src/tenants/dto/requests/get-tenant-dto.ts
+++ b/apps/klubiq-dashboard/src/tenants/dto/requests/get-tenant-dto.ts
@@ -1,0 +1,16 @@
+import { PageOptionsDto } from '@app/common/dto/pagination/page-options.dto';
+import { IsOptional } from 'class-validator';
+import { IntersectionType } from '@nestjs/swagger';
+
+export class TenantFilterDto {
+	@IsOptional()
+	search?: string;
+}
+export class GetTenantDto extends IntersectionType(
+	TenantFilterDto,
+	PageOptionsDto,
+) {
+	get skip(): number {
+		return (this.page - 1) * this.take;
+	}
+}

--- a/apps/klubiq-dashboard/src/tenants/dto/responses/lease-tenant.dto.ts
+++ b/apps/klubiq-dashboard/src/tenants/dto/responses/lease-tenant.dto.ts
@@ -1,0 +1,29 @@
+import { Expose, Type } from 'class-transformer';
+
+export class TenantDto {
+	@Expose() id: string;
+	@Expose() fullName: string;
+	@Expose() email: string;
+	@Expose() phone?: string;
+}
+
+export class LeaseDto {
+	@Expose() id: string;
+	@Expose() leaseStart: Date;
+	@Expose() leaseEnd: Date;
+	@Expose() rentAmount: number;
+	@Expose() unitId?: string;
+}
+
+export class LeaseTenantResponseDto {
+	@Expose() id: string;
+	@Expose() isPrimaryTenant: boolean;
+
+	@Expose()
+	@Type(() => TenantDto)
+	tenant: TenantDto;
+
+	@Expose()
+	@Type(() => LeaseDto)
+	lease: LeaseDto;
+}

--- a/apps/klubiq-dashboard/src/tenants/services/tenants.service.ts
+++ b/apps/klubiq-dashboard/src/tenants/services/tenants.service.ts
@@ -1,0 +1,35 @@
+import { Injectable } from '@nestjs/common';
+import { LeaseTenantRepository } from '@app/common/repositories/leases-tenant.repositiory';
+import { PageDto, PageMetaDto } from '@app/common';
+import { LeaseTenantResponseDto } from '../dto/responses/lease-tenant.dto';
+import { GetTenantDto } from '../dto/requests/get-tenant-dto';
+
+@Injectable()
+export class TenantsService {
+	constructor(private readonly leaseTenantRepository: LeaseTenantRepository) {}
+
+	async findAll(
+		getTenantDto?: GetTenantDto,
+	): Promise<PageDto<LeaseTenantResponseDto>> {
+		const [entities, count] =
+			await this.leaseTenantRepository.findAllLeasesTenant(getTenantDto);
+		const pageMetaDto = new PageMetaDto({
+			itemCount: count,
+			pageOptionsDto: getTenantDto,
+		});
+		const propertiesPageData: any = new PageDto(entities, pageMetaDto);
+		return propertiesPageData;
+	}
+
+	async findOne(id: string) {
+		return this.leaseTenantRepository.getTenantById(id);
+	}
+
+	async findByLeaseId(leaseId: string): Promise<LeaseTenantResponseDto[]> {
+		return this.leaseTenantRepository.findByLeaseId(leaseId);
+	}
+
+	async findByOrganizationId(orgnizationUuid: string) {
+		return this.leaseTenantRepository.organizationTenants(orgnizationUuid);
+	}
+}

--- a/apps/klubiq-dashboard/src/tenants/tenants.module.ts
+++ b/apps/klubiq-dashboard/src/tenants/tenants.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { TenantsController } from './controller/tenants.controller';
+import { TenantsService } from './services/tenants.service';
+import { LeaseTenantRepository } from '@app/common';
+
+@Module({
+	controllers: [TenantsController],
+	providers: [TenantsService, LeaseTenantRepository],
+})
+export class TenantsModule {}

--- a/libs/common/src/repositories/leases-tenant.repositiory.ts
+++ b/libs/common/src/repositories/leases-tenant.repositiory.ts
@@ -4,6 +4,9 @@ import { BadRequestException, Injectable, Logger } from '@nestjs/common';
 import { EntityManager } from 'typeorm';
 import { TenantUser } from '../database/entities/tenant.entity';
 import { LeasesTenants } from '../database/entities/leases-tenants.entity';
+import { LeaseTenantResponseDto } from 'apps/klubiq-dashboard/src/tenants/dto/responses/lease-tenant.dto';
+import { GetTenantDto } from 'apps/klubiq-dashboard/src/tenants/dto/requests/get-tenant-dto';
+import { OrganizationTenants } from '../database/entities/organization-tenants.entity';
 
 @Injectable()
 export class LeaseTenantRepository extends BaseRepository<LeasesTenants> {
@@ -19,7 +22,6 @@ export class LeaseTenantRepository extends BaseRepository<LeasesTenants> {
 		isPrimaryTenant: boolean,
 		manager: EntityManager = this.manager,
 	) {
-		console.log('ABOUT TO MAP TENANT TO LEASE');
 		if (!tenantId || !leaseId) {
 			throw new BadRequestException('Tenant ID and Lease ID must be provided.');
 		}
@@ -40,13 +42,161 @@ export class LeaseTenantRepository extends BaseRepository<LeasesTenants> {
 			throw new BadRequestException('Lease not found.');
 		}
 
-		console.log('ABOUT TO CREATE LEASE TENANT');
 		const leasesTenants = manager.create(LeasesTenants, {
 			tenant,
 			lease,
 			isPrimaryTenant,
 		});
-		console.log('LEASE TENANT CREATED');
+
 		return manager.save(LeasesTenants, leasesTenants);
+	}
+
+	async getTenantById(tenantId: string, manager: EntityManager = this.manager) {
+		if (!tenantId) {
+			throw new BadRequestException('Tenant ID is required.');
+		}
+
+		const tenant = await manager
+			.createQueryBuilder(TenantUser, 'tenant')
+			.leftJoinAndSelect('tenant.profile', 'profile')
+			.where('tenant.id = :tenantId', { tenantId })
+			.select([
+				'tenant.id',
+				'tenant.isActive',
+				'profile.firstName',
+				'profile.email',
+				'profile.lastName',
+				'profile.phoneNumber',
+			])
+			.getOne();
+
+		if (!tenant) {
+			throw new BadRequestException('Tenant not found.');
+		}
+
+		return tenant;
+	}
+
+	async getTenantByLeaseId(
+		leaseId: string,
+		manager: EntityManager = this.manager,
+	) {
+		if (!leaseId) {
+			throw new BadRequestException('Lease ID is required.');
+		}
+
+		const lease = await manager.findOne(Lease, {
+			where: { id: leaseId },
+		});
+
+		if (!lease) {
+			throw new BadRequestException('Lease not found.');
+		}
+
+		return manager.find(LeasesTenants, {
+			where: { leaseId },
+			relations: ['tenant'],
+		});
+	}
+
+	async findByLeaseId(leaseId: string): Promise<LeaseTenantResponseDto[]> {
+		const records: any = await this.getTenantByLeaseId(leaseId);
+		return Promise.all(
+			records.map(async (record) => {
+				const profile = await record.tenant.profile;
+
+				return {
+					id: record.id,
+					isPrimaryTenant: record.isPrimaryTenant,
+					tenant: {
+						id: record.tenant.id,
+						fullName: profile.firstName + ' ' + profile.lastName,
+						email: profile.email,
+						phone: profile.phoneNumber,
+					},
+					lease: {
+						id: record.leaseId,
+						leaseStart: record.lease?.startDate, // optional chaining if lease is not eager loaded
+						leaseEnd: record.lease?.endDate,
+						rentAmount: record.lease?.rentAmount,
+						unitId: record.lease?.unit_unitnumber,
+						isDraft: record.lease?.isDraft,
+						lastPaymentDate: record.lease?.lastPaymentDate,
+						name: record.lease?.name,
+						customPaymentFrequency: record.lease?.customPaymentFrequency,
+						deletedAt: record.lease?.deletedAt,
+						createdDate: record.lease?.createdDate,
+						securityDeposit: record.lease?.securityDeposit,
+					},
+				};
+			}),
+		);
+	}
+
+	async getAllLeasesTenant(manager: EntityManager = this.manager) {
+		return manager.find(LeasesTenants, {
+			relations: ['tenant', 'lease'],
+		});
+	}
+
+	async findAllLeasesTenant(
+		getTenantDto: GetTenantDto,
+	): Promise<[LeaseTenantResponseDto[], number]> {
+		const [records, total] = await this.manager
+			.getRepository(LeasesTenants)
+			.createQueryBuilder('lt')
+			.leftJoinAndSelect('lt.tenant', 'tenant')
+			.leftJoinAndSelect('lt.lease', 'lease')
+			.skip((getTenantDto.page - 1) * getTenantDto.skip)
+			.getManyAndCount();
+
+		const items: LeaseTenantResponseDto[] = await Promise.all(
+			records.map(async (record) => {
+				const profile = await record.tenant.profile;
+				return {
+					id: record.id,
+					isPrimaryTenant: record.isPrimaryTenant,
+					tenant: {
+						id: record.tenant.id,
+						fullName: `${profile.firstName} ${profile.lastName}`,
+						email: profile.email,
+						phone: profile.phoneNumber,
+					},
+					lease: {
+						id: record.lease.id,
+						leaseStart: record.lease.startDate,
+						leaseEnd: record.lease.endDate,
+						rentAmount: record.lease.rentAmount,
+						unitId: record.lease.unit_unitnumber,
+					},
+				};
+			}),
+		);
+
+		return [items, total];
+	}
+
+	async organizationTenants(
+		organizationUuid: string,
+		manager: EntityManager = this.manager,
+	) {
+		if (!organizationUuid) {
+			throw new BadRequestException('Organization ID is required.');
+		}
+
+		const tenants = await manager
+			.createQueryBuilder(OrganizationTenants, 'orgTenant')
+			.leftJoinAndSelect('orgTenant.tenant', 'tenant')
+			.leftJoinAndSelect('tenant.profile', 'profile')
+			.where('orgTenant.organizationUuid = :organizationUuid', {
+				organizationUuid,
+			})
+			.getManyAndCount();
+
+		if (!tenants) {
+			throw new BadRequestException('Tenants not found for this organization.');
+		}
+
+		return tenants;
 	}
 }


### PR DESCRIPTION
Pull Request Summary

1. Extended tenant lease logic to also persist tenant data into the organization_tenants table for better tenant-organization mapping.

2. New Endpoints Implemented:

- Create a single tenant.

- Retrieve tenants associated with a specific organization.

- Retrieve the tenant associated with a specific lease.

- Retrieve all tenants who are associated with leases.

